### PR TITLE
MOB-2532 - Add integration attributes

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "button/button-merchant-ios" "1.0.1"
-github "mparticle/mparticle-apple-sdk" "7.5.7"
+github "mparticle/mparticle-apple-sdk" "7.7.3"

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		DB0773E41DB916B80031F3E3 /* MPKitButton.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0773E21DB916B80031F3E3 /* MPKitButton.m */; };
 		DE811925214C4CF900AAC951 /* mParticle_Button.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0773D61DB916610031F3E3 /* mParticle_Button.framework */; };
 		DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */; };
+		DEAA37222180E11800915875 /* MPKitButton+ButtonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +35,9 @@
 		DE811920214C4CF900AAC951 /* mParticle-ButtonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ButtonTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "mParticle-ButtonTests.swift"; sourceTree = "<group>"; };
 		DE81192E214C4F5400AAC951 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DEAA371F2180E11700915875 /* mParticle-ButtonTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "mParticle-ButtonTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		DEAA37202180E11800915875 /* MPKitButton+ButtonTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPKitButton+ButtonTests.h"; sourceTree = "<group>"; };
+		DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPKitButton+ButtonTests.m"; sourceTree = "<group>"; };
 		DEEEE6A3214C57BF006B5C06 /* ButtonMerchant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ButtonMerchant.framework; path = Carthage/Build/iOS/ButtonMerchant.framework; sourceTree = "<group>"; };
 		DEEEE6A4214C57CA006B5C06 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -100,10 +104,21 @@
 		DE81192C214C4F5400AAC951 /* mParticle-ButtonTests */ = {
 			isa = PBXGroup;
 			children = (
+				DEAA37232180E11F00915875 /* Helpers */,
 				DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */,
 				DE81192E214C4F5400AAC951 /* Info.plist */,
 			);
 			path = "mParticle-ButtonTests";
+			sourceTree = "<group>";
+		};
+		DEAA37232180E11F00915875 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				DEAA371F2180E11700915875 /* mParticle-ButtonTests-Bridging-Header.h */,
+				DEAA37202180E11800915875 /* MPKitButton+ButtonTests.h */,
+				DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -178,6 +193,7 @@
 					DE81191F214C4CF900AAC951 = {
 						CreatedOnToolsVersion = 9.4.1;
 						DevelopmentTeam = 39F27QYP2C;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -266,6 +282,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */,
+				DEAA37222180E11800915875 /* MPKitButton+ButtonTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,7 +428,7 @@
 				);
 				INFOPLIST_FILE = "mParticle-Button/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -439,7 +456,7 @@
 				);
 				INFOPLIST_FILE = "mParticle-Button/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -454,6 +471,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -465,12 +483,13 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -482,6 +501,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -493,11 +513,12 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DE0F93972148654000E0FF7F"
+               BlueprintIdentifier = "DE81191F214C4CF900AAC951"
                BuildableName = "mParticle-ButtonTests.xctest"
                BlueprintName = "mParticle-ButtonTests"
                ReferencedContainer = "container:mParticle-Button.xcodeproj">

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -54,6 +54,7 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 @interface MPKitButton ()
 
+@property (nonatomic, strong) MParticle *mParticleInstance;
 @property (nonatomic, strong, nonnull) MPIButton *button;
 @property (nonatomic, copy)   NSString *applicationId;
 @property (nonatomic, strong) NSURLSession *session;
@@ -74,6 +75,25 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"Button"
                                                            className:NSStringFromClass(self)];
     [MParticle registerExtension:kitRegister];
+}
+
+
+- (MParticle *)mParticleInstance {
+    if (!_mParticleInstance) {
+        return [MParticle sharedInstance];
+    }
+
+    return _mParticleInstance;
+}
+
+
+- (void)trackIncomingURL:(NSURL *)url {
+    [ButtonMerchant trackIncomingURL:url];
+    NSString *attributionToken = ButtonMerchant.attributionToken;
+    if (attributionToken) {
+        NSDictionary<NSString *, NSString *> *integrationAttributes = @{ MPKitButtonIntegrationAttribution: attributionToken };
+        [_mParticleInstance setIntegrationAttributes:integrationAttributes forKit:[[self class] kitCode]];
+    }
 }
 
 
@@ -109,21 +129,21 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url options:(nullable NSDictionary<NSString *, id> *)options {
-    [ButtonMerchant trackIncomingURL:url];
+    [self trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(nullable id)annotation {
-    [ButtonMerchant trackIncomingURL:url];
+    [self trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler {
-    [ButtonMerchant trackIncomingUserActivity:userActivity];
+    [self trackIncomingURL:userActivity.webpageURL];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
@@ -1,0 +1,7 @@
+#import "mParticle_Button.h"
+
+@interface MPKitButton (ButtonTests)
+@property (nonatomic, strong) MParticle *mParticleInstance;
+@end
+
+

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
@@ -1,0 +1,5 @@
+#import "MPKitButton+ButtonTests.h"
+
+@implementation MPKitButton (ButtonTests)
+@dynamic mParticleInstance;
+@end

--- a/mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h
+++ b/mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "MPKitButton+ButtonTests.h"

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -20,6 +20,16 @@ extension ButtonMerchant {
     }
 }
 
+class TestMParticle: MParticle {
+    var actualIntegrationAttributes: [String : String]!
+    var actualKitCode: NSNumber!
+    override func setIntegrationAttributes(_ attributes: [String : String], forKit kitCode: NSNumber) -> MPKitExecStatus {
+        actualIntegrationAttributes = attributes
+        actualKitCode = kitCode
+        return MPKitExecStatus()
+    }
+}
+
 class TestMPKitAPI: MPKitAPI {
     var onAttributionCompleteTestHandler: ((MPAttributionResult?, NSError?) -> ())!
     open override func onAttributionComplete(with result: MPAttributionResult?, error: Error?) {
@@ -27,10 +37,10 @@ class TestMPKitAPI: MPKitAPI {
     }
 }
 
-
 class mParticle_ButtonTests: XCTestCase {
 
-    var buttonKit = MPKitButton()
+    var testMParticleInstance: TestMParticle!
+    var buttonKit: MPKitButton!
     var buttonInstance: MPIButton!
     var applicationId: String = "app-\(arc4random_uniform(10000))"
 
@@ -42,9 +52,16 @@ class mParticle_ButtonTests: XCTestCase {
         Stub.error = nil
 
         // Start the Button kit.
+        buttonKit = MPKitButton()
+        testMParticleInstance = TestMParticle()
+        buttonKit.mParticleInstance = testMParticleInstance
         let configuration = ["application_id": applicationId]
         buttonKit.didFinishLaunching(withConfiguration: configuration)
         buttonInstance = buttonKit.providerKitInstance as! MPIButton
+    }
+
+    func testKitCode() {
+        XCTAssertEqual(MPKitButton.kitCode(), 1022)
     }
 
     func testDidFinishLaunchingWithConfiguration() {
@@ -63,6 +80,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testOpenURLSourceApplicationAnnotationTracks() {
@@ -77,6 +95,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testContinueUserActivityTracks() {
@@ -93,6 +112,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testPostInstallCheckOnAttribution() {


### PR DESCRIPTION
# Overview

This change sets the integration attributes on MParticle each time we receive an incoming url. This was omitted in the migration to the merchant library. You can see the previous implementation [here](https://github.com/mparticle-integrations/mparticle-apple-integration-button/blob/master/mParticle-Button/MPKitButton.m#L62).

## Proposed changes
- Sets attribution token from each incoming url as mParticle "integration attributes"
- Updates tests to verify additional behavior