### PR TITLE
Add post install attribution to integration attributes

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,31 @@
+name: Run tests
+
+on: pull_request
+
+jobs:
+  build:
+
+    runs-on:  macos-latest
+    
+    steps:
+    - name: Clone Repo
+      uses: actions/checkout@v1
+
+    - uses: actions/cache@v2
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-carthage-
+
+    - name: Carthage
+      run: carthage update
+    
+    - name: Test
+      run: |
+        xcodebuild \
+          -project mParticle-Button.xcodeproj \
+          -scheme mParticle-Button \
+          -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" \
+          clean test
+  

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "button/button-merchant-ios" "1.0.1"
-github "mparticle/mparticle-apple-sdk" "7.10.0"
+github "button/button-merchant-ios" "1.3.0"
+github "mparticle/mparticle-apple-sdk" "7.16.2"

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
+            BuildableName = "mParticle_Button.framework"
+            BlueprintName = "mParticle-Button"
+            ReferencedContainer = "container:mParticle-Button.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-            BuildableName = "mParticle_Button.framework"
-            BlueprintName = "mParticle-Button"
-            ReferencedContainer = "container:mParticle-Button.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -57,7 +57,7 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 @property (nonatomic, strong) MParticle *mParticleInstance;
 @property (nonatomic, strong, nonnull) MPIButton *button;
 @property (nonatomic, copy)   NSString *applicationId;
-@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSNotificationCenter *defaultCenter;
 
 @end
 
@@ -80,20 +80,22 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 - (MParticle *)mParticleInstance {
     if (!_mParticleInstance) {
-        return [MParticle sharedInstance];
+        _mParticleInstance = [MParticle sharedInstance];
     }
-
     return _mParticleInstance;
+}
+
+
+- (NSNotificationCenter *)defaultCenter {
+    if (!_defaultCenter) {
+        _defaultCenter = NSNotificationCenter.defaultCenter;
+    }
+    return _defaultCenter;
 }
 
 
 - (void)trackIncomingURL:(NSURL *)url {
     [ButtonMerchant trackIncomingURL:url];
-    NSString *attributionToken = ButtonMerchant.attributionToken;
-    if (attributionToken) {
-        NSDictionary<NSString *, NSString *> *integrationAttributes = @{ MPKitButtonIntegrationAttribution: attributionToken };
-        [_mParticleInstance setIntegrationAttributes:integrationAttributes forKit:[[self class] kitCode]];
-    }
 }
 
 
@@ -107,8 +109,12 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeRequirementsNotMet];
         return execStatus;
     }
-
+    
     [ButtonMerchant configureWithApplicationId:_applicationId];
+    [self.defaultCenter addObserver:self
+                           selector:@selector(observeAttributionTokenDidChangeNotification:)
+                               name:ButtonMerchant.AttributionTokenDidChangeNotification
+                             object:nil];
 
     _configuration = configuration;
     _started       = YES;
@@ -169,6 +175,15 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
         attributionResult.linkInfo = linkInfo;
         [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
     }];
+}
+
+
+- (void)observeAttributionTokenDidChangeNotification:(NSNotification *)note {
+    NSString *attributionToken = note.userInfo[ButtonMerchant.AttributionTokenKey];
+    if (attributionToken) {
+        NSDictionary<NSString *, NSString *> *integrationAttributes = @{ MPKitButtonIntegrationAttribution: attributionToken };
+        [self.mParticleInstance setIntegrationAttributes:integrationAttributes forKit:[[self class] kitCode]];
+    }
 }
 
 @end

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
@@ -2,6 +2,7 @@
 
 @interface MPKitButton (ButtonTests)
 @property (nonatomic, strong) MParticle *mParticleInstance;
+@property (nonatomic, strong) NSNotificationCenter *defaultCenter;
 @end
 
 


### PR DESCRIPTION
## Overview

Forward the post install attribution token to mParticle's integration attributes.

## To do
- [x] End-to-end test
- [x] Open PR upstream